### PR TITLE
Fix Lightbox.destroy() state leak, doc typos, and add test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Alternatively, we also provide Tebex.js via our own CDN, which you can add as a 
 
 When installing Tebex.js this way, the `Tebex` object will become available globally on the `window` object.
 
-We recommend using `defer` on the script to prevent it from blocking your website's initial page render, but when doing do, it's important to **wait for the page `load` event** before you begin configuring the checkout:
+We recommend using `defer` on the script to prevent it from blocking your website's initial page render, but when doing so, it's important to **wait for the page `load` event** before you begin configuring the checkout:
 
 ```html
 <script>

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -216,7 +216,7 @@ export default class Checkout {
     
     /**
      * Subscribe to Tebex checkout events, such as when the embed is closed or when a payment is completed.
-     * NOTE: None of these events should not be used to confirm actual receipt of payment - you should use Webhooks for that.
+     * NOTE: These events should not be used to confirm actual receipt of payment - you should use Webhooks for that.
      */
     on<T extends CheckoutEvent>(event: T, callback: CheckoutEventMap[T]): Unsubscribe {
         // @ts-ignore - handles legacy event name

--- a/src/components/lightbox.tsx
+++ b/src/components/lightbox.tsx
@@ -93,9 +93,9 @@ export class Lightbox {
     }
 
     destroy() {
-        if (!this.root.parentNode)
-            return;
-        this.hide(false);
+        // Always run cleanup, even if the root has already been detached, so listeners
+        // and the global open-state flag don't leak across destroy/re-show cycles.
+        void this.hide(false);
     }
 
     #onClickOutside = (e: MouseEvent) => {

--- a/tests/components/lightbox.test.ts
+++ b/tests/components/lightbox.test.ts
@@ -97,6 +97,18 @@ describe("Lightbox", () => {
             lightbox.destroy();
             expect(document.body.querySelector('.tebex-js-lightbox')).toBeNull();
         });
+
+        test("Releases the global open-state lock even if root has already been detached", async () => {
+            await lightbox.show();
+            // Simulate the root being removed by something other than the lightbox itself.
+            lightbox.root.remove();
+            lightbox.destroy();
+
+            // If the global lock weren't released, constructing + showing a new lightbox would assert.
+            const next = new Lightbox({ name: "test-lightbox-2" });
+            await expect(next.show()).resolves.toBeUndefined();
+            next.destroy();
+        });
     });
 
 });

--- a/tests/utils/detect.test.ts
+++ b/tests/utils/detect.test.ts
@@ -63,6 +63,14 @@ describe("isMobile", () => {
         expect(isMobile("800px", "760px")).toEqual(true);
     });
 
-    // TODO: test that this returns false on larger viewports
+    test("Returns false when viewport is larger than the supplied thresholds", () => {
+        // 1px thresholds will not match unless the browser viewport is impossibly small.
+        expect(isMobile("1px", "1px")).toEqual(false);
+    });
+
+    test("Returns true when matchMedia is unavailable", () => {
+        vi.stubGlobal('matchMedia', undefined);
+        expect(isMobile("800px", "760px")).toEqual(true);
+    });
 
 });


### PR DESCRIPTION
## Summary

Three small, independent fixes plus a coverage bump. Bundled because each is too
small to warrant its own PR; happy to split if preferred.

### 1. `Lightbox.destroy()` skipped cleanup when root was already detached
`destroy()` returned early on `!this.root.parentNode`, leaving the click/keydown
listeners attached to `<body>` and `globalIsLightboxOpen` stuck at `true`. The
next `show()` would then assert *"There is already a lightbox open"*. Fix: always
delegate to `hide(false)`, which has its own guards for the DOM removal path.

A regression test reproduces the failure mode by detaching the root externally
before calling `destroy()`, then verifies a fresh `Lightbox` can still `show()`.

### 2. Double negative in `Checkout.on()` JSDoc
> NOTE: None of these events should not be used to confirm actual receipt…

The double negative inverts the intended meaning. Reworded to *"These events
should not be used…"*.

### 3. README typo
*"but when doing do"* → *"but when doing so"*.

### 4. Filled in two `isMobile` test TODOs
- Returns \`false\` on viewports larger than the supplied thresholds
- Returns \`true\` (the documented "be safe" branch) when \`matchMedia\` is unavailable

The sibling \`isEnvBrowser\` TODO is left in place — \`window\` is non-configurable
in the Playwright browser test env, so \`vi.stubGlobal('window', undefined)\`
throws. Would need a separate Node-env test setup; left for a future PR.

## Test plan
- [x] \`npx vitest run tests/utils/detect.test.ts tests/components/lightbox.test.ts\` — 21 passed
- [ ] CI passes